### PR TITLE
Update gh pat for CSO and CSPO

### DIFF
--- a/prod/cso/config/secret.yaml
+++ b/prod/cso/config/secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-    git-access-token: ENC[AES256_GCM,data:UeeND2gQfXi5Wu3zkmaSxmZBMAV6WTR2tymPHmSTtQBFA/BTBuQMvL/RaxNGtV/HTr1y8KBfSEStjV1LCEdjmRms4x+wfHrtGbNwObiRnwyVHpRsd2LWNs0/kaYB5pa0Y17dbOmMaG++iu4xRgNSi6uEW/fbQfy5jxNyTQ==,iv:q1OqHd2o7SfzafS3HSNVeVhTrlFsO01Bl0XJF1HFFQk=,tag:2mTil6K+bJg45E23B6at0w==,type:str]
+    git-access-token: ENC[AES256_GCM,data:+aS6mhNKFdY15km7ZmHreq+4+oDb2nCK1bKW4m/nF0lu+0J24DvAJ639eRmXg3hqZiQ1l9GpQvQ6wNjoqY2U3QlhT7CZFj1NESRbUr1Cx2ErkPSdsmexcBiedevzJ6a1oD+GwR1mCmBaXmuu0gzQzvDjgX7lOknPrRf0ow==,iv:StN7O6EQaQL672JwgHVnVDNym8PjoYprA/uHAlfAPjU=,tag:jnM5lblwbg9ZLElcG8hFnw==,type:str]
     git-org-name: ENC[AES256_GCM,data:lzrfKuXPdrw2fzSdWidHkJ3z4bkYXd87Sw8rOQ==,iv:FMrxVUACHHxgqBsDVs0DyVaCQ8RmL8qU/HUJzeWlR2A=,tag:Z/0fz7iXcr9kSAnBTKvotA==,type:str]
     git-provider: ENC[AES256_GCM,data:yv5a0/ptvQY=,iv:ZcNbhpVcDkUexAcvzb/0hf8kPbqBQAWrfD8/jytcHes=,tag:60nuBr1EGv1uEO9Jgu/N7A==,type:str]
     git-repo-name: ENC[AES256_GCM,data:76nlCC/Qq+w3/L9IiSSueM6sidc=,iv:hPaDvjya8yCzLZ+U0Dx7W88YaRnMqdcJD4Rmzf/zTv0=,tag:ZfYve2M+n5Lz6crNVLMR9Q==,type:str]
@@ -15,8 +15,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-05-28T14:19:14Z"
-    mac: ENC[AES256_GCM,data:cfJe04/ZmTKcDuEhVF6tEOIDpTNPBOla63NmYvh4j4FCCaJzJICvxLvEe/0QXNjulkPc6x9u4/uaqi/LQSKQERqKKmIC+OtRZsc/6ndLukRd0cLq4LF9mWc9Owb++YtBnMQM0N5xUsXi/RL/P/F+BSpb+xaX++iMFaCQ6soijJY=,iv:FgtJZecq2OrsiV1JMgO99v392noomf91CHF95IrZRuk=,tag:F4MxeR00LTkGE3zXbjqDRQ==,type:str]
+    lastmodified: "2024-08-30T12:04:31Z"
+    mac: ENC[AES256_GCM,data:1c7SviIUQbQ/OYKsf/eI4mZD4k/Ezl3IryRuaWc0W2zUQz3KpksmCpIeEGQ+MkTxF98FBvDklQV4b5R4Zemvna+aYVYLSAJFc272BS+aH3niW5SWD313yrBH3zB+5ZqUiCDqs84QnN/7XjEb7yYkcxVutO0QaB6mRcGGj4vf+sw=,iv:dES0oIK40xYtki5h2b+/iTjOnyqE7Fnh1hjfmI0JXL4=,tag:E9MdAnuMhjbSujz/Nx0iwQ==,type:str]
     pgp:
         - created_at: "2024-07-02T12:30:59Z"
           enc: |-
@@ -127,4 +127,4 @@ sops:
             -----END PGP MESSAGE-----
           fp: B6829414FCD33331EBD08EC3F70112A73CB97C21
     encrypted_regex: ^(data|stringData)$
-    version: 3.8.1
+    version: 3.9.0

--- a/prod/cspo/config/secret.yaml
+++ b/prod/cspo/config/secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-    git-access-token: ENC[AES256_GCM,data:RPeUKwoslsja4VKowBfMXUBPKPDpU3VJtyfBXjTPsJ6CAjmJHYnsnfwfXQ4x8EFZY4W45bSNpd5CCpM2RkTlrapwBLaLhlC0Ghh0yekLHcVrMP6BNvKcQSWl0Lum/sc1o8lCwM3W5eD2et3Rjlc/CZ4XmUlogTHeQzMRng==,iv:k9jPmgK82kr3EZbzl7pX/qSw1Q7i5vc0J1K7wQUPzXM=,tag:xfL8Ei4ASODV31gPeXiEDA==,type:str]
+    git-access-token: ENC[AES256_GCM,data:oU4IJZjKuXzXAfQ02L1zW8fwI72Yns07NIPdQD92SUkoy1A5leg9FIUpxOdjs2yz1ZKACG14zxIUSFWnhwXS5COtRdovW+kjmCkO7AuvGiNoe/DPIpvQGJYzZ6PflNHru1V7Tp0d53Ld3f/tLMt3kSoyUGnQtNq5nksXZg==,iv:RkZrmFcp0CLv6mIQjRBc2BxSBIySTogywhN4mqmWbNo=,tag:LFLU5MjCAp/FK7njJfa/Ow==,type:str]
     git-org-name: ENC[AES256_GCM,data:GxbH/T9e+rQKUjHcHeurDAwshbz7aaFDEN6jEA==,iv:f9TWI5ZkMvY8nnT0yPrChJLUKSIMtlaXiyflPGzYNi8=,tag:3J63PZ48VeKlf/KO2BC1+w==,type:str]
     git-provider: ENC[AES256_GCM,data:1iTPv8j/KgA=,iv:z3/pVljwlvpm6xjnDon8bcgcA0cwHVMx1xUqfIpUIas=,tag:P4CSCTtt2Y7Jtj639qq/Ew==,type:str]
     git-repo-name: ENC[AES256_GCM,data:uhNF48toC17uxyHmf/lIDrU7vls=,iv:JVZGlOLhw88EDYLH8cQMAQZ9Cz2OYgVeFqjvThyZLqQ=,tag:tRJo5raDkicpNcnJA2TVng==,type:str]
@@ -15,8 +15,8 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-06-26T14:51:06Z"
-    mac: ENC[AES256_GCM,data:4nrB/4DpbsgQizTR8gjkcwSd+fxuu6dkoyFQfNQlhRDrhEgezrVTXGQk/Jy7tTc+q70so/DxnspOm3Jn2xDp4hclrCvUY0dfVNEjDE5xc2uqx1XhMWwcsH43vtA90Ga96wqZXy6vQMNwRQ/POLI9skfGpMUzwob18qbCMfRcWAE=,iv:ySaSEbC0XHbDP9ouvCiqsh+5+CNe4uAAvrbujc8cCWo=,tag:RlAU6Wc62o7zw56gWnSgbg==,type:str]
+    lastmodified: "2024-08-30T12:03:16Z"
+    mac: ENC[AES256_GCM,data:xMFW0lGtnSH5TtLZCdl3Jn4Qm8ewarSVLnvN0ImTqUEWYCJ0QA/5gf+nAntq81YmEgA7vyj6Bf14EAaHqPz03pXH9EMR02TVeUm4ef7YnMDka0jY9HSyNQ8PvdhXSETNjj1IoykRyL8DXI4D3PRr/x3NQgx+Ly0Z/ccNRi9+ns0=,iv:ZeW/JZAYI1KUgxcDNk7G6w6ah0RQeyOE7GSFy257a0Y=,tag:xcMHcBI4//BgY19JMp0j+A==,type:str]
     pgp:
         - created_at: "2024-07-02T12:31:06Z"
           enc: |-
@@ -127,4 +127,4 @@ sops:
             -----END PGP MESSAGE-----
           fp: B6829414FCD33331EBD08EC3F70112A73CB97C21
     encrypted_regex: ^(data|stringData)$
-    version: 3.8.1
+    version: 3.9.0


### PR DESCRIPTION
CSO and CSPO currently can't download Cluster Stacks releases because of expired GitHub Token